### PR TITLE
Disallow duplicate appointments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApptCommand.java
@@ -25,7 +25,7 @@ public class AddApptCommand extends Command {
     public static final String MESSAGE_PATIENT_NOT_FOUND = "Patient with NRIC %1$s not found";
 
     public static final String MESSAGE_SUCCESS = "New appointment added for person with IC %1$s on %2$s";
-    public static final String MESSAGE_FAILURE = "Failed to add appointment: %1$s";
+    public static final String MESSAGE_FAILURE_APPOINTMENT_EXISTS = "This appointment already exists!";
 
     private final String ic;
     private final String date;
@@ -56,6 +56,9 @@ public class AddApptCommand extends Command {
 
         // We expect only one person to match by NRIC since NRIC is unique
         Person patientFound = filteredPersons.get(0);
+        if (patientFound.hasAppointment(date)) {
+            throw new CommandException(MESSAGE_FAILURE_APPOINTMENT_EXISTS);
+        }
         patientFound.addAppointment(date);
 
         model.updateFilteredPersonList(new NricPredicate(ic));

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -31,4 +31,12 @@ public class Appointment {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
         return apptDateTime.format(formatter);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Appointment other) {
+            return this.apptDateTime.equals(other.apptDateTime);
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/address/model/appointment/AppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentList.java
@@ -65,4 +65,8 @@ public class AppointmentList {
         }
         return s;
     }
+
+    public boolean hasAppointment(Appointment appointment) {
+        return this.appointments.contains(appointment);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -162,4 +162,7 @@ public class Person {
                 .toString();
     }
 
+    public boolean hasAppointment(String date) {
+        return this.appointmentList.hasAppointment(Appointment.createAppointment(date));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApptCommandTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class AddApptCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullDate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddApptCommand("S3286024I", null));
+    }
+
+    @Test
+    public void addAppt_nullNric_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddApptCommand(null, "02/02/2026 15:00"));
+    }
+
+    @Test
+    public void addAppt_success() throws CommandException {
+        AddApptCommand command = new AddApptCommand("S3286024I", "02/02/2026 15:00");
+        CommandResult commandResult = command.execute(model);
+        assertEquals(new CommandResult(String.format(AddApptCommand.MESSAGE_SUCCESS,
+                "S3286024I", "02/02/2026 15:00")), commandResult);
+    }
+
+    @Test
+    public void addAppt_sameAppointment_fail() throws CommandException {
+        AddApptCommand command = new AddApptCommand("S3286024I", "02/02/2026 17:00");
+        command.execute(model);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+}

--- a/src/test/java/seedu/address/model/appointment/AppointmentListTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentListTest.java
@@ -1,6 +1,7 @@
 package seedu.address.model.appointment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -48,4 +49,13 @@ public class AppointmentListTest {
         assertEquals("01/01/2025 15:00", appointmentList.getAppointments().get(0).toString());
         assertEquals("02/01/2025 16:00", appointmentList.getAppointments().get(1).toString());
     }
+
+    @Test
+    public void containsAppointment_validAppointment_success() {
+        AppointmentList appointmentList = new AppointmentList();
+        appointmentList.addAppointment("01/01/2028 15:00");
+        assertTrue(appointmentList.hasAppointment(Appointment.createAppointment("01/01/2028 15:00")));
+        assertFalse(appointmentList.hasAppointment(Appointment.createAppointment("02/02/2028 15:00")));
+    }
+
 }

--- a/src/test/java/seedu/address/model/appointment/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentTest.java
@@ -1,0 +1,22 @@
+package seedu.address.model.appointment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AppointmentTest {
+
+    @Test
+    public void equalAppointment_success() {
+        Appointment testAppointment = Appointment.createAppointment("09/09/2029 15:00");
+        assertEquals(testAppointment, Appointment.createAppointment("09/09/2029 15:00"));
+    }
+
+    @Test
+    public void notEqualAppointment_success() {
+        Appointment testAppointment = Appointment.createAppointment("09/09/2029 15:00");
+        assertNotEquals(testAppointment, Appointment.createAppointment("09/09/2029 15:01"));
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -33,7 +33,7 @@ public class PersonTest {
     @Test
     public void addAppointment_validAppointment_success() {
         Person person = new PersonBuilder().build();
-        String appointmentDateTime = "01/01/2025 15:00";
+        String appointmentDateTime = "01/01/2026 15:00";
         person.addAppointment(appointmentDateTime);
         assertTrue(person.getAppointmentList().stream()
                 .anyMatch(appointment -> appointment.toString().equals(appointmentDateTime)));
@@ -42,9 +42,25 @@ public class PersonTest {
     @Test
     public void addAppointment_validAppointmentObject_success() {
         Person person = new PersonBuilder().build();
-        Appointment appointment = Appointment.createAppointment("01/01/2025 15:00");
+        Appointment appointment = Appointment.createAppointment("01/01/2026 15:00");
         person.addAppointment(appointment);
         assertTrue(person.getAppointmentList().contains(appointment));
+    }
+
+    @Test
+    public void hasAppointment_validAppointment_success() {
+        Person person = new PersonBuilder().build();
+        Appointment appointment = Appointment.createAppointment("01/01/2026 15:00");
+        person.addAppointment(appointment);
+        assertTrue(person.hasAppointment("01/01/2026 15:00"));
+    }
+
+    @Test
+    public void hasAppointment_invalidAppointment_fail() {
+        Person person = new PersonBuilder().build();
+        Appointment appointment = Appointment.createAppointment("01/01/2026 15:00");
+        person.addAppointment(appointment);
+        assertFalse(person.hasAppointment("01/01/2026 15:01"));
     }
 
     @Test


### PR DESCRIPTION
Added additional check for existence of appointment before a potentially-duplicate appointment is added.
Fixes #228 
Fixes #216 
Fixes #198